### PR TITLE
feat(GUI-17): add keyboard shortcuts with ? help panel

### DIFF
--- a/src/features/home/app/components/keyboard-shortcuts-panel.browser.spec.tsx
+++ b/src/features/home/app/components/keyboard-shortcuts-panel.browser.spec.tsx
@@ -1,0 +1,52 @@
+import * as module from "react-i18next";
+import { describe, expect, it, vi } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { page, render } from "@/tests/utils";
+
+import { KeyboardShortcutsPanel } from "./keyboard-shortcuts-panel";
+
+vi.mock("react-i18next", { spy: true });
+vi.mocked(module.useTranslation).mockImplementation(
+  // @ts-expect-error lightweight mock
+  () => ({ t: (key: string) => key }),
+);
+
+describe("KeyboardShortcutsPanel", () => {
+  it("renders all shortcut rows when open", async () => {
+    render(<KeyboardShortcutsPanel open onOpenChange={() => {}} />);
+
+    await expect.element(page.getByText("shortcuts.title")).toBeVisible();
+    await expect.element(page.getByText("shortcuts.copy")).toBeVisible();
+    await expect.element(page.getByText("shortcuts.download")).toBeVisible();
+    await expect.element(page.getByText("shortcuts.experience")).toBeVisible();
+    await expect.element(page.getByText("shortcuts.help")).toBeVisible();
+  });
+
+  it("renders kbd key badges for each shortcut", async () => {
+    render(<KeyboardShortcutsPanel open onOpenChange={() => {}} />);
+
+    for (const key of ["C", "D", "E", "?"]) {
+      await expect
+        .element(page.getByText(key, { exact: true }).first())
+        .toBeVisible();
+    }
+  });
+
+  it("is not visible when closed", async () => {
+    render(<KeyboardShortcutsPanel open={false} onOpenChange={() => {}} />);
+
+    await expect
+      .element(page.getByText("shortcuts.title"))
+      .not.toBeInTheDocument();
+  });
+
+  it("calls onOpenChange when Escape is pressed", async () => {
+    const onOpenChange = vi.fn();
+    render(<KeyboardShortcutsPanel open onOpenChange={onOpenChange} />);
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(onOpenChange).toHaveBeenCalledWith(false, expect.anything());
+  });
+});

--- a/src/features/home/app/components/keyboard-shortcuts-panel.tsx
+++ b/src/features/home/app/components/keyboard-shortcuts-panel.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from "react-i18next";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const shortcuts = [
+  { key: "C", i18nKey: "shortcuts.copy" },
+  { key: "D", i18nKey: "shortcuts.download" },
+  { key: "E", i18nKey: "shortcuts.experience" },
+  { key: "?", i18nKey: "shortcuts.help" },
+] as const;
+
+interface KeyboardShortcutsPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const KeyboardShortcutsPanel = ({
+  open,
+  onOpenChange,
+}: KeyboardShortcutsPanelProps) => {
+  const { t } = useTranslation("common");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{t("shortcuts.title")}</DialogTitle>
+        </DialogHeader>
+        <ul className="flex flex-col gap-3 pt-1">
+          {shortcuts.map(({ key, i18nKey }) => (
+            <li key={key} className="flex items-center justify-between gap-4">
+              <span className="text-sm text-muted-foreground">
+                {t(i18nKey)}
+              </span>
+              <kbd className="inline-flex h-6 min-w-6 items-center justify-center rounded border border-border bg-muted px-1.5 font-mono text-xs font-medium text-foreground">
+                {key}
+              </kbd>
+            </li>
+          ))}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/features/home/app/hooks/use-keyboard-shortcuts.browser.spec.tsx
+++ b/src/features/home/app/hooks/use-keyboard-shortcuts.browser.spec.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { isTypingTarget } from "./use-keyboard-shortcuts";
+
+const makeEl = (
+  tag: string,
+  extra?: (el: HTMLElement) => void,
+): HTMLElement => {
+  const el = document.createElement(tag);
+  extra?.(el);
+  return el;
+};
+
+describe("isTypingTarget", () => {
+  it("returns false for null", () => {
+    expect(isTypingTarget(null)).toBe(false);
+  });
+
+  it("returns true for INPUT", () => {
+    expect(isTypingTarget(makeEl("input"))).toBe(true);
+  });
+
+  it("returns true for TEXTAREA", () => {
+    expect(isTypingTarget(makeEl("textarea"))).toBe(true);
+  });
+
+  it("returns true for SELECT", () => {
+    expect(isTypingTarget(makeEl("select"))).toBe(true);
+  });
+
+  it("returns true for a contenteditable element", () => {
+    expect(
+      isTypingTarget(
+        makeEl("div", (el) => el.setAttribute("contenteditable", "true")),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for a regular div", () => {
+    expect(isTypingTarget(makeEl("div"))).toBe(false);
+  });
+
+  it("returns false for a button", () => {
+    expect(isTypingTarget(makeEl("button"))).toBe(false);
+  });
+});

--- a/src/features/home/app/hooks/use-keyboard-shortcuts.ts
+++ b/src/features/home/app/hooks/use-keyboard-shortcuts.ts
@@ -4,11 +4,11 @@ import { toast } from "sonner";
 
 import { scrollToSection } from "@/features/home/app/scroll-to-section";
 
-const isTypingTarget = (el: Element | null): boolean => {
+export const isTypingTarget = (el: Element | null): boolean => {
   if (!el) return false;
-  const tag = (el as HTMLElement).tagName;
+  const tag = el.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
-  return (el as HTMLElement).isContentEditable;
+  return el instanceof HTMLElement && el.isContentEditable;
 };
 
 export const useKeyboardShortcuts = () => {
@@ -20,16 +20,17 @@ export const useKeyboardShortcuts = () => {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (isTypingTarget(document.activeElement)) return;
 
-      const key = e.key;
+      const key = e.key.toLowerCase();
 
-      if (key === "c" || key === "C") {
+      if (key === "c") {
         navigator.clipboard
           .writeText("naimi.guillaume@gmail.com")
-          .then(() => toast.success(t("shortcuts.copied")));
+          .then(() => toast.success(t("shortcuts.copied")))
+          .catch(() => toast.error(t("shortcuts.copyFailed")));
         return;
       }
 
-      if (key === "d" || key === "D") {
+      if (key === "d") {
         const a = document.createElement("a");
         a.href = `/api/cv-pdf?locale=${i18n.language}`;
         a.download = "";
@@ -37,12 +38,12 @@ export const useKeyboardShortcuts = () => {
         return;
       }
 
-      if (key === "e" || key === "E") {
+      if (key === "e") {
         scrollToSection("experience");
         return;
       }
 
-      if (key === "?") {
+      if (e.key === "?") {
         setIsHelpOpen((prev) => !prev);
       }
     };

--- a/src/features/home/app/hooks/use-keyboard-shortcuts.ts
+++ b/src/features/home/app/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+import { scrollToSection } from "@/features/home/app/scroll-to-section";
+
+const isTypingTarget = (el: Element | null): boolean => {
+  if (!el) return false;
+  const tag = (el as HTMLElement).tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  return (el as HTMLElement).isContentEditable;
+};
+
+export const useKeyboardShortcuts = () => {
+  const { t, i18n } = useTranslation("common");
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isTypingTarget(document.activeElement)) return;
+
+      const key = e.key;
+
+      if (key === "c" || key === "C") {
+        navigator.clipboard
+          .writeText("naimi.guillaume@gmail.com")
+          .then(() => toast.success(t("shortcuts.copied")));
+        return;
+      }
+
+      if (key === "d" || key === "D") {
+        const a = document.createElement("a");
+        a.href = `/api/cv-pdf?locale=${i18n.language}`;
+        a.download = "";
+        a.click();
+        return;
+      }
+
+      if (key === "e" || key === "E") {
+        scrollToSection("experience");
+        return;
+      }
+
+      if (key === "?") {
+        setIsHelpOpen((prev) => !prev);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [t, i18n.language]);
+
+  return { isHelpOpen, setIsHelpOpen };
+};

--- a/src/features/home/app/page-home.tsx
+++ b/src/features/home/app/page-home.tsx
@@ -28,6 +28,8 @@ const Footer = () => {
       <div className="mx-auto flex max-w-4xl flex-col items-center justify-between gap-4 px-4 text-xs text-muted-foreground sm:flex-row">
         <p>
           {t("common:footer.copyright", { year })} {t("common:footer.built")}
+          {" · "}
+          <span className="opacity-60">{t("common:shortcuts.hint")}</span>
         </p>
         <div className="flex items-center gap-4">
           <a

--- a/src/features/home/app/page-home.tsx
+++ b/src/features/home/app/page-home.tsx
@@ -12,10 +12,12 @@ import { EducationSection } from "./components/education-section";
 import { Experience } from "./components/experience";
 import { HeroSection } from "./components/hero-section";
 import { HomeNav } from "./components/home-nav";
+import { KeyboardShortcutsPanel } from "./components/keyboard-shortcuts-panel";
 import { ProjectShowcase } from "./components/project-showcase";
 import { Skills } from "./components/skills";
 import { StatStrip } from "./components/stat-strip";
 import { TechCloud } from "./components/tech-cloud";
+import { useKeyboardShortcuts } from "./hooks/use-keyboard-shortcuts";
 
 const Footer = () => {
   const { t } = useTranslation(["common"]);
@@ -61,10 +63,12 @@ const Footer = () => {
 
 export const PageHome = () => {
   const hydrated = useHydrated();
+  const { isHelpOpen, setIsHelpOpen } = useKeyboardShortcuts();
 
   return (
     <>
       <HomeNav />
+      <KeyboardShortcutsPanel open={isHelpOpen} onOpenChange={setIsHelpOpen} />
       <PageLayout>
         <PageLayoutContent>
           <main

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -70,5 +70,14 @@
   "footer": {
     "copyright": "© {{year}} Guillaume Naimi.",
     "built": "Built with React + Tailwind."
+  },
+  "shortcuts": {
+    "title": "Keyboard Shortcuts",
+    "hint": "Press ? for keyboard shortcuts",
+    "copied": "Email copied to clipboard",
+    "copy": "Copy email address",
+    "download": "Download CV",
+    "experience": "Scroll to experience",
+    "help": "Open this help panel"
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -73,8 +73,9 @@
   },
   "shortcuts": {
     "title": "Keyboard Shortcuts",
-    "hint": "Press ? for keyboard shortcuts",
+    "hint": "Press ? for shortcuts",
     "copied": "Email copied to clipboard",
+    "copyFailed": "Could not copy to clipboard",
     "copy": "Copy email address",
     "download": "Download CV",
     "experience": "Scroll to experience",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -70,5 +70,14 @@
   "footer": {
     "copyright": "© {{year}} Guillaume Naimi.",
     "built": "Construit avec React + Tailwind."
+  },
+  "shortcuts": {
+    "title": "Raccourcis clavier",
+    "hint": "Appuyez sur ? pour les raccourcis",
+    "copied": "Email copié dans le presse-papier",
+    "copy": "Copier l'adresse e-mail",
+    "download": "Télécharger le CV",
+    "experience": "Aller à l'expérience",
+    "help": "Ouvrir ce panneau d'aide"
   }
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -75,6 +75,7 @@
     "title": "Raccourcis clavier",
     "hint": "Appuyez sur ? pour les raccourcis",
     "copied": "Email copié dans le presse-papier",
+    "copyFailed": "Impossible de copier dans le presse-papier",
     "copy": "Copier l'adresse e-mail",
     "download": "Télécharger le CV",
     "experience": "Aller à l'expérience",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ const resolve = (filePath: string) => path.resolve(__dirname, filePath);
 
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    include: ["@base-ui/react/dialog"],
+  },
   test: {
     projects: [
       {


### PR DESCRIPTION
## Summary

- Global `keydown` listener on the home page handles `C` (copy email to clipboard), `D` (download CV), `E` (scroll to experience section), and `?` (toggle help panel)
- `KeyboardShortcutsPanel` dialog lists all shortcuts with `<kbd>` badges; dismissible via Escape or outside click
- Guards prevent shortcuts from firing when modifier keys are held or when focus is in a form element
- EN and FR locale strings added under `shortcuts.*` in `common.json`

## Test plan

- [ ] Press `C` on home page → toast "Email copied to clipboard", clipboard contains `naimi.guillaume@gmail.com`
- [ ] Press `D` → CV PDF download starts (locale-aware)
- [ ] Press `E` → page scrolls to experience section
- [ ] Press `?` → help panel opens; press `Escape` → closes; click outside → closes
- [ ] Switch to FR locale and repeat — all strings in French
- [ ] Focus a text input and press `C`/`D`/`E`/`?` — no shortcuts fire
- [ ] `bun run lint` and `bun run test` pass

Closes GUI-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)