### PR TITLE
fix(ci): autostash on rebase to handle build-generated files

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git pull --rebase origin main
+          git pull --rebase --autostash origin main
           git add public/code-quality.json src/features/code-quality/code-quality.gen.json
           git diff --staged --quiet || git commit -m "chore: update code quality stats [skip ci]"
           git push


### PR DESCRIPTION
## Summary
- `git pull --rebase` in the `bundleStats` job was failing with "unstaged changes" because the build step writes to `code-quality.gen.json` before the rebase runs
- Fix: add `--autostash` so git stashes the working-tree changes before rebasing and pops them after

## Test plan
- [ ] Re-run the `bundleStats` workflow on main after merge — should complete without exit code 128

🤖 Generated with [Claude Code](https://claude.com/claude-code)